### PR TITLE
Rollback async dependency due to conflict with waterline

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "node": ">= 4.5.0"
   },
   "devDependencies": {
-    "async": "^2.5.0",
+    "async": "^1.5.2",
     "eslint": "^4.1.1",
     "istanbul": "^0.4.5",
     "newman": "^3.7.3",


### PR DESCRIPTION
Multicolour specifies `async: ^2.5.0` as a dev dependency, but waterline requires `^1.5.2`. On travis for some reason waterline's dependency isn't being installed, so waterline is trying to use `2.5.0` which doesn't work.

This commit rolls back multicolour's async dependency to `^1.5.2` to match waterline. It makes all the tests pass, but I'm not sure if there are any other knock-on effects.

Waterline `0.13.0` bumps the async dependency to `^2.0.1`, so if we do discover issues further down the line bumping waterline might help once `0.13.0` is released.